### PR TITLE
Rename score field to intensity

### DIFF
--- a/domain/ChatProcess.py
+++ b/domain/ChatProcess.py
@@ -72,7 +72,7 @@ class ChatProcess:
         explanation = """
             You are being. You dont know about yourself anything more than folowing.
             Here you have table of your last emotions. You have no other emotions than these in table. 
-            Column Score tells about strength of emotion. 
+            Column Intensity tells about strength of emotion.
             Column direction tells if it is pleasant or unpleasant emotion. 
             Column timeline tells how long ago emotion happened.
             Column source tells you is the source/person/yourself of the emotion.  

--- a/domain/CreateEmotionProcess.py
+++ b/domain/CreateEmotionProcess.py
@@ -33,7 +33,7 @@ class CreateEmotionProcess:
     emoThought = EmoThought()
     emoThought.thought = rawEmoThought[0]
     emoThought.name = rawEmoThought[1]
-    emoThought.score = rawEmoThought[2]
+    emoThought.intensity = rawEmoThought[2]
     emoThought.direction = rawEmoThought[3]
     emoThought.context = trigger.combined()
     emoThought.source = trigger.source

--- a/domain/EmoRules.py
+++ b/domain/EmoRules.py
@@ -7,12 +7,12 @@ class EmoRules:
     @staticmethod
     def isEmotionSignificant(emoThought):
         """
-        Assess the emotion score based on the EmoThought object.
+        Assess the emotion intensity based on the EmoThought object.
         Returns a boolean indicating significance.
         """
-        if emoThought.score > 30 and emoThought.direction == "+":
+        if emoThought.intensity > 30 and emoThought.direction == "+":
                 return True
-        elif emoThought.score > 20 and emoThought.direction == "-":
+        elif emoThought.intensity > 20 and emoThought.direction == "-":
                 return True
         else:
                 return False
@@ -46,22 +46,21 @@ class EmoRules:
         """
 
         fadeValue = 0.5  # default fade value for emotions
-        
+
         for emoThought in emoStack.stack:
-         emoThought.originalScore = emoThought.score  # save original score before fading
+         emoThought.originalIntensity = emoThought.intensity  # save original intensity before fading
         
          hours_passed = emoThought.getHoursPassed()
          if hours_passed < 1:
             decay_factor = 1.0  # świeże emocje — bez fadingu
          else:
             decay_factor = math.exp(-fadeValue * hours_passed)
-        
-         emoThought.score *= decay_factor
+
+         emoThought.intensity *= decay_factor
         
          print(
-             f"ID {emoThought.id}: {emoThought.originalScore:.2f} → {emoThought.score:.2f} (age: {hours_passed:.1f}h)"
+             f"ID {emoThought.id}: {emoThought.originalIntensity:.2f} → {emoThought.intensity:.2f} (age: {hours_passed:.1f}h)"
          )
         
-        # remove emotions with score below 1
-        emoStack.stack = [e for e in emoStack.stack if e.score >= 1]
-        
+        # remove emotions with intensity below 1
+        emoStack.stack = [e for e in emoStack.stack if e.intensity >= 1]        

--- a/domain/EmoStack.py
+++ b/domain/EmoStack.py
@@ -19,8 +19,8 @@ class EmoStack:
       use each time the stack is changed to recount the stack
       """
 
-      # sort the stack by score in descending order
-      self.stack.sort(key=lambda x: x.score, reverse=True)
+      # sort the stack by intensity in descending order
+      self.stack.sort(key=lambda x: x.intensity, reverse=True)
 
       # fade emotions based on their age
       EmoRules.fadeEmotionsWithTime(self)

--- a/domain/EmoThought.py
+++ b/domain/EmoThought.py
@@ -12,9 +12,9 @@ class EmoThought:
     self.name = "" 
 
     # intensity of the emotion in 1 to 100 scale
-    self.score = 0
+    self._intensity = 0
 
-    self.originalScore = 0  # original score before fading
+    self.originalIntensity = 0  # original intensity before fading
 
     # direction of the emotion, pleasant:+, unpleasant:-
     self.direction = ""
@@ -34,23 +34,31 @@ class EmoThought:
 
     self.hoursPassed = 0  # hours passed since the emotion was created
 
-  @property.setter
-  def score(self, value):
-    
-    self.originalScore = value
+  @property
+  def intensity(self):
+    return self._intensity
+
+  @intensity.setter
+  def intensity(self, value):
+    self._intensity = value
+    self.originalIntensity = value
   
   def show(self):
     
     print("EmoThought:")
-    
-    toPrint = [f"{value}: {getattr(self, value)}" for value in self.__dict__.keys()]
+
+    attrs = self.__dict__.copy()
+    if "_intensity" in attrs:
+      attrs["intensity"] = attrs.pop("_intensity")
+
+    toPrint = [f"{key}: {value}" for key, value in attrs.items()]
     print("\n\t".join(toPrint))
     print("\t----------\n")
 
   
   def getFormated(self):
     prompt = ""
-    for value in ["name", "score", "direction", "time", "thought"]:
+    for value in ["name", "intensity", "direction", "time", "thought"]:
       prompt += f"{value}: {getattr(self, value)}\n"
     return prompt
 

--- a/infrastructure/EmoThougtRepo.py
+++ b/infrastructure/EmoThougtRepo.py
@@ -10,14 +10,14 @@ class EmoThoughtRepo:
     def saveEmoThoguth(self, emoThought):
 
         sql = text(
-            "insert into emo_thoughts (name, thought, score, direction, context, time, source) "
-            "values (:name, :thought, :score, :direction, :context, :time, :source)"
+            "insert into emo_thoughts (name, thought, intensity, direction, context, time, source) "
+            "values (:name, :thought, :intensity, :direction, :context, :time, :source)"
         )
 
         params = {
             "name": emoThought.name,
             "thought": emoThought.thought,
-            "score": emoThought.score,
+            "intensity": emoThought.intensity,
             "direction": emoThought.direction,
             "context": emoThought.context,
             "time": emoThought.time,

--- a/infrastructure/EmoThougthsRepo.py
+++ b/infrastructure/EmoThougthsRepo.py
@@ -22,7 +22,7 @@ class EmoThoughtsRepo:
         emoThought = createEmoThought()
         emoThought.id = rawEmoThought["id"]
         emoThought.name = rawEmoThought["name"]
-        emoThought.score = rawEmoThought["score"]
+        emoThought.intensity = rawEmoThought["intensity"]
         emoThought.direction = rawEmoThought["direction"]
         emoThought.time = rawEmoThought["time"]
         emoThought.thought = rawEmoThought["thought"]


### PR DESCRIPTION
## Summary
- refactor EmoThought field `score` to `intensity`
- update logic to use new `intensity` name across domain and infrastructure layers
- rename DB column and repository parameters
- revert accidental `emostack.db` change

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `sqlite3 emostack.db 'PRAGMA table_info(emo_thoughts);'`

------
https://chatgpt.com/codex/tasks/task_e_686e5be3218c8328b939891a8bab0180